### PR TITLE
Pass in token so this can be used on a private repo

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,9 @@ inputs:
     description: "Should this action automatically alphabetize your dictionary.txt"
     default: false
     type: boolean
+  token: 
+    description: "GitHub PAT if the repository is private" 
+    type: string
 
 runs:
   using: "composite"
@@ -58,6 +61,7 @@ runs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
+        token: ${{ inputs.token }}
 
     # Find existing comment to update
     - name: Find Comment
@@ -67,7 +71,8 @@ runs:
         issue-number: ${{ github.event.pull_request.number }}
         comment-author: 'github-actions[bot]'
         body-includes: "OTTR Check Results"
-
+        token: ${{ inputs.token }}
+        
     # Post initial status
     - name: Post initial status
       uses: peter-evans/create-or-update-comment@v4
@@ -81,6 +86,7 @@ runs:
 
           _Last Updated: ${{ steps.build-components.outputs.time }}_
         edit-mode: replace
+        token: ${{ inputs.token }}
 
     # Spelling Check
     - name: Run spelling check
@@ -226,6 +232,7 @@ runs:
 
           _Last Updated: ${{ steps.build-components.outputs.time }}_
         edit-mode: replace
+        token: ${{ inputs.token }}
 
     # Final exit if any checks failed
     - name: Check for failures


### PR DESCRIPTION
## Summary 

I'm working on a private repo. Turns out ottr-reports can't work well there. But there's no reason it shouldn't. 