### PR TITLE
Adjust reports so that it can be run without a triggering PR event

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ In other words, what number of errors should make this check fail? Default is `0
 
 ## Outputs
 
-A comment on your pull request with a summary of your checsk and a zip file with the respective reports :
+A comment on your pull request with a summary of your checks and a zip file with the respective reports :
 'spell_check_results.tsv', 'url_checks.csv', or question_error_report.tsv',
 
 
@@ -52,4 +52,4 @@ A comment on your pull request with a summary of your checsk and a zip file with
 
 All checks are run by the `jhudsl/ottrpal` docker image which contains the `ottrpal` R package.
 
-You can use the [ottrpal R package](https://github.com/ottrproject/ottrpal) yourself for other uses.
+You can use the [`ottrpal` R package](https://github.com/ottrproject/ottrpal) yourself for other uses.

--- a/action.yml
+++ b/action.yml
@@ -71,6 +71,7 @@ runs:
 
     # Post initial status
     - name: Post initial status
+      if: github.event_name == 'pull_request'
       uses: peter-evans/create-or-update-comment@v4
       id: initial-comment
       with:
@@ -198,7 +199,7 @@ runs:
 
     # Update comment with final results
     - name: Update results comment
-      if: always()
+      if: github.event_name == 'pull_request'
       uses: peter-evans/create-or-update-comment@v4
       with:
         comment-id: ${{ steps.initial-comment.outputs.comment-id }}

--- a/action.yml
+++ b/action.yml
@@ -61,6 +61,7 @@ runs:
 
     # Find existing comment to update
     - name: Find Comment
+      if: github.event_name == 'pull_request'
       uses: peter-evans/find-comment@v3
       id: find-comment
       with:


### PR DESCRIPTION
## Problem

Periodic url checker is failing and not completing.

Example: https://github.com/ottrproject/OTTR_Template/pull/17 ([job here](https://github.com/ottrproject/OTTR_Template/actions/runs/14767963658/job/41462955865))

The test for this action also appears to be failing: https://github.com/ottrproject/ottr-reports/actions/runs/15072257331

## Cause (?)

I think this is because when ottr-reports is run as a periodic check (not during a PR) it fails when trying to locate the comment:

```
Run peter-evans/find-comment@v3
Error: Not Found
Run mkdir -p all_reports
Run peter-evans/create-or-update-comment@v4
Error: Missing either 'issue-number' or 'comment-id'.
Run if [[ "false" == "true" ]]; then
```

## Solution

Add option `if: github.event_name == 'pull_request'` so that it won't try to comment if there's no PR to comment on. It will just make the artifact.

Examples of implementation:

1. workflow completing but failing because of url and spelling errors: https://github.com/ottrproject/ottr-reports-periodic-checker-test/actions/runs/15072947435

2. Workflow completing and passing because of no url and spelling errors: https://github.com/ottrproject/ottr-reports-periodic-checker-test/actions/runs/15073078876/job/42374033080

3. Works with a PR: https://github.com/ottrproject/ottr-reports-periodic-checker-test/pull/1

## Review

If this looks ok according to the implementation above, I'll delete the fork at ottr-reports-periodic-checker-test.